### PR TITLE
fix(ci): resolve semantic-release branch protection issues

### DIFF
--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -24,7 +24,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           fetch-depth: 0
-          token: ${{ secrets.GITHUB_TOKEN }}
+          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -42,7 +42,7 @@ jobs:
             @semantic-release/exec@6
             conventional-changelog-conventionalcommits@7
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN || secrets.GITHUB_TOKEN }}
 
       - name: Output release information
         if: steps.semantic.outputs.new-release-published == 'true'


### PR DESCRIPTION
## Summary
- Configure semantic-release to use SEMANTIC_RELEASE_TOKEN secret for branch protection bypass
- Enable automated releases to push to protected main branch
- Fall back to GITHUB_TOKEN if custom token not available

## Technical Details
The semantic-release workflow was failing with:
```
remote: error: GH006: Protected branch update failed for refs/heads/main.
remote: - Changes must be made through a pull request.
```

This PR updates the workflow to support a custom token with sufficient permissions to bypass branch protection rules for automated releases.