### PR TITLE
feat: configurable logging and annotation improvements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,3 +51,4 @@ push-to-github.sh
 # Claude Code
 .claude
 CLAUDE.md
+deployment-annotator

--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,7 @@ go 1.24.0
 toolchain go1.24.4
 
 require (
+	go.uber.org/zap v1.27.0
 	k8s.io/api v0.33.2
 	k8s.io/apimachinery v0.33.2
 	k8s.io/client-go v0.33.2
@@ -43,7 +44,6 @@ require (
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/x448/float16 v0.8.4 // indirect
 	go.uber.org/multierr v1.11.0 // indirect
-	go.uber.org/zap v1.27.0 // indirect
 	golang.org/x/net v0.38.0 // indirect
 	golang.org/x/oauth2 v0.27.0 // indirect
 	golang.org/x/sync v0.12.0 // indirect

--- a/helm/deployment-annotator-controller/templates/deployment.yaml
+++ b/helm/deployment-annotator-controller/templates/deployment.yaml
@@ -65,6 +65,10 @@ spec:
                 secretKeyRef:
                   name: {{ include "deployment-annotator-controller.fullname" . }}-grafana
                   key: GRAFANA_API_KEY
+            - name: LOG_LEVEL
+              value: {{ .Values.controller.log.level | quote }}
+            - name: LOG_DEVELOPMENT
+              value: {{ .Values.controller.log.development | quote }}
       {{- with .Values.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/helm/deployment-annotator-controller/values.yaml
+++ b/helm/deployment-annotator-controller/values.yaml
@@ -1,5 +1,5 @@
 # Default values for deployment-annotator-controller
-replicaCount: 2
+replicaCount: 1
 
 image:
   repository: ghcr.io/perun-engineering/deployment-annotator-for-grafana
@@ -73,6 +73,12 @@ grafana:
 controller:
   # Maximum number of concurrent reconciles
   maxConcurrentReconciles: 5
+  # Logging configuration
+  log:
+    # Log level (info, debug, error)
+    level: "info"
+    # Development mode (enables debug logs and stack traces)
+    development: false
 
 # RBAC configuration
 rbac:


### PR DESCRIPTION
## Summary
- Fix empty annotation issue by updating annotations in place instead of clearing them
- Change annotation prefixes from `grafana.io/` to `deployment-annotator.io/`  
- Add configurable logging via Helm chart
- Set replica count to 1 to prevent race conditions

## Changes
- Update `handleNewDeploymentVersion` to create new annotations immediately instead of clearing and waiting
- Change annotation constants to use `deployment-annotator.io/` prefix
- Add `controller.log.level` and `controller.log.development` to Helm values
- Set `replicaCount: 1` to avoid duplicate processing
- Change "Processing deployment" log to DEBUG level