### PR TITLE
fix: namespace watching not working due to incorrect predicate filter

### DIFF
--- a/main.go
+++ b/main.go
@@ -771,7 +771,7 @@ func namespaceLabelChangedPredicate() predicate.Predicate {
 // SetupWithManager sets up the controller with the Manager
 func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&appsv1.Deployment{}).
+		For(&appsv1.Deployment{}, builder.WithPredicates(specChangedPredicate())).
 		Watches(
 			&appsv1.ReplicaSet{},
 			handler.EnqueueRequestsFromMapFunc(r.mapReplicaSetToDeployment),
@@ -784,7 +784,6 @@ func (r *DeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		WithOptions(controller.Options{
 			MaxConcurrentReconciles: DefaultMaxConcurrentReconciles,
 		}).
-		WithEventFilter(specChangedPredicate()).
 		Complete(r)
 }
 


### PR DESCRIPTION
## Problem
Namespace label changes were not being detected due to `specChangedPredicate()` being applied globally via `WithEventFilter()`, which filtered out all namespace events.

## Solution
Move `specChangedPredicate()` to only apply to the primary `For()` resource using `builder.WithPredicates()`.

## Impact
- Namespace label addition now immediately processes existing deployments
- Namespace label removal now cleans up all deployment annotations