### PR TITLE
feat: add selective workload watching

### DIFF
--- a/helm/deployment-annotator-controller/templates/configmap.yaml
+++ b/helm/deployment-annotator-controller/templates/configmap.yaml
@@ -6,3 +6,6 @@ metadata:
     {{- include "deployment-annotator-controller.labels" . | nindent 4 }}
 data:
   GRAFANA_URL: {{ .Values.grafana.url | quote }}
+  WATCH_DEPLOYMENTS: {{ .Values.controller.watch.deployments | quote }}
+  WATCH_STATEFULSETS: {{ .Values.controller.watch.statefulSets | quote }}
+  WATCH_DAEMONSETS: {{ .Values.controller.watch.daemonSets | quote }}

--- a/helm/deployment-annotator-controller/templates/deployment.yaml
+++ b/helm/deployment-annotator-controller/templates/deployment.yaml
@@ -60,6 +60,21 @@ spec:
                 configMapKeyRef:
                   name: {{ include "deployment-annotator-controller.fullname" . }}-config
                   key: GRAFANA_URL
+            - name: WATCH_DEPLOYMENTS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "deployment-annotator-controller.fullname" . }}-config
+                  key: WATCH_DEPLOYMENTS
+            - name: WATCH_STATEFULSETS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "deployment-annotator-controller.fullname" . }}-config
+                  key: WATCH_STATEFULSETS
+            - name: WATCH_DAEMONSETS
+              valueFrom:
+                configMapKeyRef:
+                  name: {{ include "deployment-annotator-controller.fullname" . }}-config
+                  key: WATCH_DAEMONSETS
             - name: GRAFANA_API_KEY
               valueFrom:
                 secretKeyRef:

--- a/helm/deployment-annotator-controller/values.yaml
+++ b/helm/deployment-annotator-controller/values.yaml
@@ -79,6 +79,11 @@ controller:
     level: "info"
     # Development mode (enables debug logs and stack traces)
     development: false
+  # Which workload kinds to watch
+  watch:
+    deployments: true
+    statefulSets: true
+    daemonSets: true
 
 # RBAC configuration
 rbac:


### PR DESCRIPTION
## Changes

- Add environment variables for selective workload watching:
  - `WATCH_DEPLOYMENTS` (default: true)
  - `WATCH_STATEFULSETS` (default: true) 
  - `WATCH_DAEMONSETS` (default: true)
- Add `controller.watch` configuration section in Helm values
- Enable conditional controller setup based on watch flags
- Update README with comprehensive configuration documentation

## Benefits

- Reduce resource usage by watching only needed workload types
- Enable gradual rollout of deployment tracking
- Avoid noise from unused workload types
- Better resource optimization for specific environments

## Configuration Examples

**Deployments only:**
```yaml
controller:
  watch:
    deployments: true
    statefulSets: false
    daemonSets: false
```

**All workloads (default):**
```yaml  
controller:
  watch:
    deployments: true
    statefulSets: true
    daemonSets: true
```