### PR TITLE
ci: replace SEMANTIC_RELEASE_TOKEN with reusable release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,6 +3,16 @@ name: Release
 on:
   release:
     types: [published]
+  workflow_call:
+    inputs:
+      tag_name:
+        description: "Release tag (e.g., v1.0.3)"
+        required: true
+        type: string
+      version:
+        description: "Release version without v prefix (e.g., 1.0.3)"
+        required: true
+        type: string
   workflow_dispatch: # Allow manual triggering
     inputs:
       release_tag:
@@ -25,7 +35,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag_name || github.event.release.tag_name }}
 
       - name: Set environment variables
         env:
@@ -39,10 +49,16 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
           INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
           REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "$EVENT_NAME" = "release" ]; then
+          if [ -n "$INPUT_VERSION" ]; then
+            # Reusable workflow call - inputs are authoritative
+            TAG_NAME="$INPUT_TAG_NAME"
+            VERSION="$INPUT_VERSION"
+          elif [ "$EVENT_NAME" = "release" ]; then
             # Release event - use release data
             VERSION="$RELEASE_TAG_NAME"
             TAG_NAME="$RELEASE_TAG_NAME"
@@ -151,7 +167,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.release.tag_name }}
+          ref: ${{ inputs.tag_name || github.event.release.tag_name }}
 
       - name: Set environment variables
         env:
@@ -165,10 +181,15 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
           INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
           REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "$EVENT_NAME" = "release" ]; then
+          if [ -n "$INPUT_VERSION" ]; then
+            TAG_NAME="$INPUT_TAG_NAME"
+            VERSION="$INPUT_VERSION"
+          elif [ "$EVENT_NAME" = "release" ]; then
             VERSION="$RELEASE_TAG_NAME"
             TAG_NAME="$RELEASE_TAG_NAME"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
@@ -264,10 +285,13 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
           INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          INPUT_VERSION: ${{ inputs.version }}
           REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "$EVENT_NAME" = "release" ]; then
+          if [ -n "$INPUT_VERSION" ]; then
+            VERSION="$INPUT_VERSION"
+          elif [ "$EVENT_NAME" = "release" ]; then
             VERSION="$RELEASE_TAG_NAME"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then
             if [ -n "$INPUT_RELEASE_TAG" ]; then
@@ -298,10 +322,15 @@ jobs:
           EVENT_NAME: ${{ github.event_name }}
           RELEASE_TAG_NAME: ${{ github.event.release.tag_name }}
           INPUT_RELEASE_TAG: ${{ github.event.inputs.release_tag }}
+          INPUT_TAG_NAME: ${{ inputs.tag_name }}
+          INPUT_VERSION: ${{ inputs.version }}
           REPOSITORY: ${{ github.repository }}
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
-          if [ "$EVENT_NAME" = "release" ]; then
+          if [ -n "$INPUT_VERSION" ]; then
+            TAG_NAME="$INPUT_TAG_NAME"
+            VERSION="$INPUT_VERSION"
+          elif [ "$EVENT_NAME" = "release" ]; then
             VERSION="$RELEASE_TAG_NAME"
             TAG_NAME="$RELEASE_TAG_NAME"
           elif [ "$EVENT_NAME" = "workflow_dispatch" ]; then

--- a/.github/workflows/semantic-release.yml
+++ b/.github/workflows/semantic-release.yml
@@ -9,7 +9,6 @@ on:
   workflow_dispatch:
 
 jobs:
-  # Semantic release with automated versioning
   semantic-release:
     name: Semantic Release
     runs-on: ubuntu-latest
@@ -19,14 +18,18 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
+    outputs:
+      new-release-published: ${{ steps.semantic.outputs.new_release_published }}
+      new-release-version: ${{ steps.semantic.outputs.new_release_version }}
+      new-release-git-tag: ${{ steps.semantic.outputs.new_release_git_tag }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
         with:
           ref: main
           fetch-depth: 0
+          fetch-tags: true
           persist-credentials: true
-          token: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
 
       - name: Set up Node.js
         uses: actions/setup-node@v6
@@ -44,15 +47,17 @@ jobs:
             @semantic-release/exec@6
             conventional-changelog-conventionalcommits@7
         env:
-          GITHUB_TOKEN: ${{ secrets.SEMANTIC_RELEASE_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Output release information
-        if: steps.semantic.outputs.new-release-published == 'true'
-        run: |
-          echo "🎉 New release published!"
-          echo "Version: ${{ steps.semantic.outputs.new-release-version }}"
-          echo "Multi-arch images have been pre-validated and published."
-          echo "The 'Release' workflow will now publish:"
-          echo "- Helm chart to OCI registry with release tag"
-          echo "- Cross-platform binary releases"
-          echo "- Release artifacts and checksums"
+  release:
+    name: Release Artifacts
+    needs: semantic-release
+    if: needs.semantic-release.outputs.new-release-published == 'true'
+    uses: ./.github/workflows/release.yml
+    with:
+      tag_name: ${{ needs.semantic-release.outputs.new-release-git-tag }}
+      version: ${{ needs.semantic-release.outputs.new-release-version }}
+    permissions:
+      contents: write
+      packages: write
+      security-events: write


### PR DESCRIPTION
## Summary
- Converts `release.yml` into a reusable workflow (`workflow_call`) accepting `tag_name` and `version` inputs while preserving `release: published` and `workflow_dispatch` triggers.
- Adds a downstream `release` job to `semantic-release.yml` that invokes `release.yml` when `new-release-published == 'true'`.
- Drops the `SEMANTIC_RELEASE_TOKEN` PAT from checkout and the semantic-release step; the default `GITHUB_TOKEN` now drives the entire chain.

## Why
The PAT existed only to make the `release: published` event fire downstream — `GITHUB_TOKEN`-created releases don't trigger workflows. Calling `release.yml` directly via `workflow_call` removes that requirement, so the secret can be deleted from repo settings.

## Follow-up
- Delete the `SEMANTIC_RELEASE_TOKEN` secret in repo settings once this is merged and the next release succeeds.