### PR TITLE
ci: install Polaris via jaxxstorm/action-install-gh-release

### DIFF
--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -175,10 +175,11 @@ jobs:
             --set image.tag=test > k8s-manifests.yaml
 
       - name: Install Polaris
-        run: |
-          # Install Polaris CLI for Kubernetes security scanning
-          curl -L https://github.com/FairwindsOps/polaris/releases/latest/download/polaris_linux_amd64.tar.gz | tar xz
-          sudo mv polaris /usr/local/bin/
+        uses: jaxxstorm/action-install-gh-release@v3.0.0
+        with:
+          repo: FairwindsOps/polaris
+          tag: latest
+          cache: enable
 
       - name: Run Polaris security scan
         run: |


### PR DESCRIPTION
## Summary
- Replaces the hardcoded `curl` install in the Kubernetes Security Scan with `jaxxstorm/action-install-gh-release@v3.0.0`, which resolves the latest Polaris release asset by name and supports caching.

## Why
Polaris v10.2.0 unified its release pipeline and renamed assets from `polaris_linux_amd64.tar.gz` to `polaris_<version>_linux_amd64.tar.gz`. The `releases/latest/download/polaris_linux_amd64.tar.gz` URL now 404s, breaking the daily scheduled Security workflow on `main` since the rename. The official `FairwindsOps/polaris/.github/actions/setup-polaris` action still hardcodes the old asset name and is itself broken for current versions, so a generic installer action is the cleanest fix.