### PR TITLE
docs: add agent skills config and first ADR

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,17 @@
+# AGENTS.md
+
+Shared configuration for AI agents and engineering skills working in this repo.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues in `perun-engineering/deployment-annotator-for-grafana` via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Canonical role names (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` + `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/adr/0001-workload-adapter-and-annotation-client-seams.md
+++ b/docs/adr/0001-workload-adapter-and-annotation-client-seams.md
@@ -1,0 +1,31 @@
+# 1. WorkloadAdapter and AnnotationClient seams
+
+Date: 2026-05-31
+
+## Status
+
+Accepted
+
+## Context
+
+The controller annotates Grafana on changes to three Kubernetes workload kinds — Deployment, StatefulSet, and DaemonSet. These kinds differ in how a version is computed, how readiness is checked, how spec/status is extracted, how lists are unpacked, and how rollout completion is detected (Deployments observe ReplicaSet events via a secondary watch; StatefulSets and DaemonSets use their own status-change predicates).
+
+Left unmanaged, those differences leak into the reconciler as type switches on concrete workload types, and the reconciler also ends up owning direct HTTP calls to Grafana plus the bookkeeping of annotation IDs. Both couplings make the orchestration logic hard to read and hard to test.
+
+## Decision
+
+Two seams isolate the variation:
+
+- **`WorkloadAdapter`** — an interface capturing every per-kind difference (version computation, readiness, spec/status extraction, list unpacking, completion-detection strategy). No code outside the adapter implementations type-switches on concrete workload types. Adapters are registered in `main`.
+- **`AnnotationClient`** — a two-method consumer-side interface (`CreateAnnotation`, `UpdateAnnotationToRegion`) defined in `internal/controller`. The concrete `grafana.Client` satisfies it; tests supply a fake.
+
+The `WorkloadReconciler` keeps orchestration only (fetch, namespace check, version, readiness) and delegates all Grafana interaction and annotation-state bookkeeping to the concrete `AnnotationLifecycle` struct, which persists annotation IDs and the tracked version as Kubernetes annotations on the workload.
+
+## Consequences
+
+- Adding a new workload kind means writing one adapter, not editing the reconciler.
+- The reconciler is unit-testable against fakes with no Grafana or live cluster.
+- The consumer-side interface keeps `internal/controller` free of a hard dependency on `internal/grafana`.
+- Adapter implementations concentrate the per-kind complexity; they are the place to look when a kind behaves unexpectedly.
+
+See `CONTEXT.md` for the domain vocabulary (Workload, Adapter, AnnotationClient, Annotation lifecycle, Completion detection).

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,33 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+This is a **single-context** repo.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root — domain vocabulary and package layout.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in (directory may not exist yet).
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/            ← created lazily by /grill-with-docs
+└── internal/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md` (e.g. Workload, Tracked namespace, Annotation lifecycle, Adapter, AnnotationClient, Completion detection). Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues in `perun-engineering/deployment-annotator-for-grafana`. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, fetching labels alongside.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,17 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Canonical role    | Label in our tracker | Meaning                                  |
+| ----------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`    | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`      | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent` | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human` | `ready-for-human`    | Requires human implementation            |
+| `wontfix`         | `wontfix`            | Will not be actioned                     |
+
+Category labels: `bug` (something is broken), `enhancement` (new feature or improvement).
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
Adds the per-repo configuration that the engineering skills (`triage`, `to-issues`, `to-prd`, `tdd`, `improve-codebase-architecture`) read, plus the first ADR.

## What

- `docs/agents/issue-tracker.md` — GitHub Issues via `gh` CLI
- `docs/agents/triage-labels.md` — canonical triage role → label mapping
- `docs/agents/domain.md` — single-context layout, `CONTEXT.md` glossary consumer rules
- `AGENTS.md` — pointer block indexing the above
- `docs/adr/0001-workload-adapter-and-annotation-client-seams.md` — records the existing `WorkloadAdapter` / `AnnotationClient` seams already described in `CONTEXT.md`

## Why

Skills assumed this config existed but it was never scaffolded. Triage state-role labels (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`) were also created in the repo to match.
