### PR TITLE
ci: bump GO_VERSION to 1.26 for k8s 0.36 / controller-runtime 0.24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ permissions:
   actions: read
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
   REGISTRY: ghcr.io
 
 jobs:

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -15,7 +15,7 @@ permissions:
   security-events: write
 
 env:
-  GO_VERSION: "1.25"
+  GO_VERSION: "1.26"
   REGISTRY: ghcr.io
 
 jobs:


### PR DESCRIPTION
#108 (controller-runtime 0.24.1) raised the `go.mod` directive to `go 1.26.0`, but CI pins `GO_VERSION: "1.25"` with `GOTOOLCHAIN=local`, so builds fail:

```
go: go.mod requires go >= 1.26.0 (running go 1.25.10; GOTOOLCHAIN=local)
```

Bumps `GO_VERSION` 1.25 → 1.26 in `ci.yml` and `security.yml` to match `go.mod` (Dockerfile already uses `golang:1.26-alpine`). Restores green `main` and unblocks #109.
